### PR TITLE
Create plugin to warn about current fuel level

### DIFF
--- a/src/js/app-main.js
+++ b/src/js/app-main.js
@@ -4,7 +4,7 @@ const config = require('../config');
 
 // ↓↓ 作ったプラグインをココでrequireする ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
 const sample = require('./plugins/sample');
-
+const fuelLevelWatcher = require('./plugins/fuel-level-watcher')
 
 // ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
 
@@ -16,6 +16,7 @@ $(() => {
     console.log('connected');
     // ↓↓ pluginのactionをココで呼ぶ ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
     sample.action(vias, render);
+    fuelLevelWatcher.action(vias, render);
 
     // ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
 

--- a/src/js/plugins/fuel-level-watcher.js
+++ b/src/js/plugins/fuel-level-watcher.js
@@ -1,0 +1,47 @@
+const TAG = '[FuelLevelWatcher]';
+const plugin = {};
+
+const THRESHOLDS = [
+  { value: 50, text: '燃料が半分になったよ' },
+  { value: 25, text: '燃料が四分の一になったよ' },
+  { value: 15, text: '燃料が残り15パーセントになったよ' },
+  { value: 10, text: '燃料が残り10パーセントになったよ' },
+  { value: 5, text: '燃料が残り5パーセントになったよ' },
+];
+
+// 給油と判断する最低限のFuel Level増加量
+const MIN_REFUEL_GAP = 10;
+
+// 把握している現在のFuel Level
+let lastFuelLevel = -100;
+
+plugin.action = (vias, callback) => {
+  vias.subscribe(FUEL_LEVEL, onFuelLevelChanged(callback), onError);
+};
+
+const onFuelLevelChanged = callback => {
+  return value => {
+    console.log(`${TAG} onFuelLevelChanged: ${lastFuelLevel} -> ${value}`);
+    value = +value
+    if (value < lastFuelLevel) {
+      let text;
+      THRESHOLDS.forEach(th => {
+        if (value <= th.value && lastFuelLevel > th.value) {
+          text = th.text;
+        }
+      })
+      if (text) {
+        callback({ text: text });
+      }
+      lastFuelLevel = value;
+    } else if (value >= lastFuelLevel + MIN_REFUEL_GAP) {
+      lastFuelLevel = value;
+    }
+  }
+};
+
+const onError = err => {
+  console.log(err);
+}
+
+module.exports = plugin;


### PR DESCRIPTION
- Fuel Levelが一定値以下になるとOutputします。ひとまず今は以下のデータを入れてます
  - 50%: "燃料が半分になったよ"
  - 25%: "燃料が四分の一になったよ"
  - 15%: "燃料が残り15パーセントになったよ"
  - 10%: "燃料が残り10パーセントになったよ"
  - 5%: "燃料が残り5パーセントになったよ"
- Fuel Levelが車の姿勢によって (?) けっこう揺らぐデータなので、10%未満の上昇は無視するようにしています (10%以上の上昇は給油とみなして値の更新に使う)