### PR TITLE
Create plugin announcing milestones of total distance

### DIFF
--- a/src/js/app-main.js
+++ b/src/js/app-main.js
@@ -8,6 +8,7 @@ const fuelLevelWatcher = require('./plugins/fuel-level-watcher')
 const interiorTemperature = require('./plugins/interior-temperature');
 const awakeness = require('./plugins/awakeness');
 const stoppedVehicleDetector = require('./plugins/stopped-vehicle-detector');
+const totalDistanceMilestones = require('./plugins/total-distance-milestones');
 // ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
 
 let isAudioPlayable = true;
@@ -18,11 +19,12 @@ $(() => {
   vias.connect(() => {
     console.log('connected');
     // ↓↓ pluginのactionをココで呼ぶ ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
-    sample.action(vias, render);
+    // sample.action(vias, render);
     awakeness.action(vias, render);
     fuelLevelWatcher.action(vias, render);
     interiorTemperature.action(vias, render);
     stoppedVehicleDetector.action(vias, render);
+    totalDistanceMilestones.action(vias, render);
     // ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
 
   });

--- a/src/js/plugins/total-distance-milestones.js
+++ b/src/js/plugins/total-distance-milestones.js
@@ -1,0 +1,86 @@
+const TAG = '[TotalDistanceMilestones]';
+const plugin = {};
+
+let currentDistance = 0;
+
+plugin.action = (vias, callback) => {
+  vias.subscribe(DISTANCE_TOTAL, onTotalDistanceChanged(callback), onError);
+};
+
+const onTotalDistanceChanged = callback => {
+  return value => {
+    value = value / 1000; // meters -> kilometers
+    console.log(`${TAG} onTotalDistanceChanged: ${currentDistance} -> ${value}`);
+    if (currentDistance !== value) {
+      currentDistance = value
+      const text = detectSingleCharacters(value) ||
+        detectIncrementalCharacters(value) ||
+        detectDecrementalCharacters(value)
+      if (text) {
+        callback({ 'text': text, kuma: 'smile', speech: { 'text': text, joy: 1.0 } });
+      }
+    }
+  }
+};
+
+const onError = err => {
+  console.log(err);
+};
+
+// ゾロ目判定
+const detectSingleCharacters = value => {
+  const str = value.toString()
+  if (str.length < 3) {
+    return null;
+  }
+
+  const firstChar = str.charAt(0);
+  for (let i = 1; i < str.length; i++) {
+    if (str.charAt(i) !== firstChar) {
+      return null;
+    }
+  }
+
+  console.log(`${TAG} detectSingleCharacters: DETECTED`);
+  return `キリ番ゲーット！走行距離が <say-as interpret-as="telephone">${value}</say-as> キロメートルになりました！ `;
+};
+
+// 階段 (増加方向) 判定
+const detectIncrementalCharacters = value => {
+  const str = value.toString();
+  if (str.length < 3 || str.length > 9) {
+    return null;
+  }
+
+  let char = str.charAt(0);
+  for (let i = 1; i < str.length; i++) {
+    if (str.charAt(i) != (+char + 1)) {
+      return null;
+    }
+    char = str.charAt(i)
+  }
+
+  console.log(`${TAG} detectIncrementalCharacters: DETECTED`);
+  return `走行距離が <say-as interpret-as="telephone">${value}</say-as> キロメートルになりました！`;
+};
+
+// 階段 (減少方向) 判定
+const detectDecrementalCharacters = value => {
+  const str = value.toString()
+  if (str.length < 3 || str.length > 9) {
+    return null;
+  }
+
+  let char = str.charAt(0);
+  for (let i = 1; i < str.length; i++) {
+    if (str.charAt(i) != (+char - 1)) {
+      return null;
+    }
+    char = str.charAt(i)
+  }
+
+  console.log(`${TAG} detectDecrementalCharacters: DETECTED`);
+  return `走行距離が <say-as interpret-as="telephone">${value}</say-as> キロメートルになりました！`;
+};
+
+module.exports = plugin;


### PR DESCRIPTION
- 積算走行距離がキリ番になったときに喋るプラグインです
  - 全部ゾロ目: 例 = 11111
  - 数字が階段状: 例 = 12345, 54321
- 数字を一桁ずつ読ませたかったので、SSMLを有効にして、 `<say-as interpret-as="telephone">` タグを使っています
  - 数字の間にスペースを挟み込めばSSML使わなくてもほぼ同じ読み上げになるのですが、こちらのほうが良い読み方になるケースがあるかもしれないと思い、SSMLを使っています